### PR TITLE
feat: browser pool with lazy creation, idle eviction, burst overflow

### DIFF
--- a/docs/plans/2026-03-07-browser-pool-design.md
+++ b/docs/plans/2026-03-07-browser-pool-design.md
@@ -1,0 +1,47 @@
+# Browser Pool Design
+
+## Date: 2026-03-07
+
+## Context
+
+The fetcher-mcp server launches and kills a Chromium process per `fetch_url` call (~1-2s cold start). With multiple simultaneous clients in HTTP transport mode, this is wasteful. Need browser pooling.
+
+## Decision
+
+Singleton pool of headless browser instances with acquire/release semantics.
+
+### Configuration (env vars)
+
+| Var | Default | Description |
+|-----|---------|-------------|
+| `BROWSER_POOL_SIZE` | 3 | Max pooled browsers |
+| `BROWSER_POOL_WARM` | 1 | Pre-warmed at startup (capped at pool size) |
+| `BROWSER_IDLE_TIMEOUT` | 300 | Seconds before idle eviction |
+
+### Behavior
+
+- **Lazy + warm**: Pre-warm N browsers at startup, create more on demand up to max
+- **Burst overflow**: When pool is exhausted, create temporary browsers beyond max — destroyed on release
+- **Idle eviction**: Browsers idle > timeout are closed, but never drops below warm count
+- **Debug bypass**: `debug: true` requests always get a burst browser with `headless: false`, never pooled
+- **Crash recovery**: Dead browsers (`!browser.isConnected()`) are discarded on acquire, replaced with fresh ones
+- **Context-per-request**: Each request creates an isolated `BrowserContext` on the acquired browser
+
+### Integration
+
+- `src/services/browserPool.ts` — pool implementation
+- `src/services/browserService.ts` — keeps context/page creation, loses `createBrowser()`
+- `src/tools/fetchUrl.ts` / `fetchUrls.ts` — acquire from pool
+- `src/server.ts` — wire pool shutdown into graceful shutdown
+- `src/index.ts` — warm pool after server starts
+
+### BrowserHandle contract
+
+```typescript
+interface BrowserHandle {
+  browser: Browser;
+  release(): Promise<void>;
+}
+```
+
+Callers MUST call `release()` in a `finally` block.

--- a/docs/plans/2026-03-07-browser-pool.md
+++ b/docs/plans/2026-03-07-browser-pool.md
@@ -1,0 +1,579 @@
+# Browser Pool Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a singleton browser pool with lazy creation, idle eviction, warm browsers, and burst overflow to eliminate per-request Chromium cold starts.
+
+**Architecture:** A `BrowserPool` singleton manages headless Chromium instances with acquire/release semantics. Tool handlers acquire a browser, create an isolated `BrowserContext` for the request, then release. Debug requests bypass the pool with temporary visible browsers. Pool integrates with server lifecycle for graceful shutdown.
+
+**Tech Stack:** Playwright (chromium), Node.js timers for idle eviction
+
+---
+
+### Task 1: Create BrowserPool service
+
+**Files:**
+- Create: `src/services/browserPool.ts`
+
+**Step 1: Write the BrowserPool class**
+
+This is the core pool implementation. No test framework exists in this project, so we verify manually via `npm run check`.
+
+```typescript
+import { Browser, chromium } from "playwright";
+import { logger } from "../utils/logger.js";
+
+export interface BrowserHandle {
+  browser: Browser;
+  release(): Promise<void>;
+}
+
+interface PooledBrowser {
+  browser: Browser;
+  idleTimer: ReturnType<typeof setTimeout> | null;
+}
+
+export class BrowserPool {
+  private static instance: BrowserPool | null = null;
+
+  private idle: PooledBrowser[] = [];
+  private inUse = 0;
+  private poolSize: number;
+  private warmCount: number;
+  private idleTimeoutMs: number;
+  private shutdownRequested = false;
+
+  private constructor() {
+    this.poolSize = this.envInt("BROWSER_POOL_SIZE", 3);
+    this.warmCount = Math.min(
+      this.envInt("BROWSER_POOL_WARM", 1),
+      this.poolSize,
+    );
+    this.idleTimeoutMs = this.envInt("BROWSER_IDLE_TIMEOUT", 300) * 1000;
+  }
+
+  static getInstance(): BrowserPool {
+    if (!BrowserPool.instance) {
+      BrowserPool.instance = new BrowserPool();
+    }
+    return BrowserPool.instance;
+  }
+
+  /** Pre-warm browsers up to warmCount. Call after server starts. */
+  async warm(): Promise<void> {
+    const toCreate = this.warmCount - this.idle.length;
+    for (let i = 0; i < toCreate; i++) {
+      try {
+        const browser = await this.launchBrowser();
+        this.addToIdle(browser);
+        logger.info(`[BrowserPool] Warmed browser ${i + 1}/${toCreate}`);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        logger.error(`[BrowserPool] Failed to warm browser: ${msg}`);
+      }
+    }
+  }
+
+  /**
+   * Acquire a browser from the pool.
+   * - If debug is true, creates a temporary visible browser (never pooled).
+   * - Otherwise returns a pooled browser, creating or bursting as needed.
+   */
+  async acquire(debug = false): Promise<BrowserHandle> {
+    if (this.shutdownRequested) {
+      throw new Error("BrowserPool is shutting down");
+    }
+
+    // Debug requests always get a temporary visible browser
+    if (debug) {
+      const browser = await this.launchBrowser(false);
+      logger.debug("[BrowserPool] Created burst browser for debug request");
+      return {
+        browser,
+        release: async () => {
+          // Debug browsers stay open — don't close
+          logger.debug("[BrowserPool] Debug browser kept open");
+        },
+      };
+    }
+
+    // Try to get an idle browser
+    while (this.idle.length > 0) {
+      const pooled = this.idle.pop()!;
+      if (pooled.idleTimer) clearTimeout(pooled.idleTimer);
+
+      if (pooled.browser.isConnected()) {
+        this.inUse++;
+        logger.debug(
+          `[BrowserPool] Acquired idle browser (idle=${this.idle.length} inUse=${this.inUse})`,
+        );
+        return this.createHandle(pooled.browser, false);
+      }
+      // Dead browser — discard and try next
+      logger.warn("[BrowserPool] Discarded dead browser from pool");
+    }
+
+    // No idle browsers — create a new one
+    const isBurst = this.inUse >= this.poolSize;
+    const browser = await this.launchBrowser();
+    this.inUse++;
+
+    if (isBurst) {
+      logger.info(
+        `[BrowserPool] Created burst browser (inUse=${this.inUse}, poolSize=${this.poolSize})`,
+      );
+    } else {
+      logger.debug(
+        `[BrowserPool] Created new pooled browser (idle=${this.idle.length} inUse=${this.inUse})`,
+      );
+    }
+
+    return this.createHandle(browser, isBurst);
+  }
+
+  /** Graceful shutdown — close all browsers. */
+  async shutdown(): Promise<void> {
+    this.shutdownRequested = true;
+    logger.info("[BrowserPool] Shutting down...");
+
+    // Clear idle timers and close idle browsers
+    for (const pooled of this.idle) {
+      if (pooled.idleTimer) clearTimeout(pooled.idleTimer);
+      await this.closeBrowser(pooled.browser);
+    }
+    this.idle = [];
+
+    // In-use browsers will be closed when their handles are released
+    // (release() checks shutdownRequested)
+    logger.info("[BrowserPool] Shutdown complete");
+  }
+
+  /** Reset singleton — for testing only. */
+  static resetInstance(): void {
+    BrowserPool.instance = null;
+  }
+
+  private createHandle(browser: Browser, isBurst: boolean): BrowserHandle {
+    let released = false;
+    return {
+      browser,
+      release: async () => {
+        if (released) return;
+        released = true;
+        this.inUse--;
+
+        if (isBurst || this.shutdownRequested) {
+          await this.closeBrowser(browser);
+          if (isBurst) {
+            logger.debug("[BrowserPool] Destroyed burst browser");
+          }
+          return;
+        }
+
+        if (browser.isConnected()) {
+          this.addToIdle(browser);
+          logger.debug(
+            `[BrowserPool] Released browser to pool (idle=${this.idle.length} inUse=${this.inUse})`,
+          );
+        } else {
+          logger.warn("[BrowserPool] Released browser was dead, discarding");
+        }
+      },
+    };
+  }
+
+  private addToIdle(browser: Browser): void {
+    const pooled: PooledBrowser = { browser, idleTimer: null };
+
+    // Only set idle timer if we're above warm count
+    if (this.idle.length >= this.warmCount) {
+      pooled.idleTimer = setTimeout(() => {
+        const idx = this.idle.indexOf(pooled);
+        if (idx !== -1 && this.idle.length > this.warmCount) {
+          this.idle.splice(idx, 1);
+          this.closeBrowser(pooled.browser);
+          logger.info(
+            `[BrowserPool] Evicted idle browser (idle=${this.idle.length})`,
+          );
+        }
+      }, this.idleTimeoutMs);
+    }
+
+    this.idle.push(pooled);
+  }
+
+  private async launchBrowser(headless = true): Promise<Browser> {
+    return chromium.launch({
+      headless,
+      args: [
+        "--disable-blink-features=AutomationControlled",
+        "--disable-features=IsolateOrigins,site-per-process",
+        "--no-sandbox",
+        "--disable-setuid-sandbox",
+        "--disable-dev-shm-usage",
+        "--disable-webgl",
+        "--disable-infobars",
+        "--disable-extensions",
+      ],
+    });
+  }
+
+  private async closeBrowser(browser: Browser): Promise<void> {
+    try {
+      if (browser.isConnected()) await browser.close();
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      logger.error(`[BrowserPool] Failed to close browser: ${msg}`);
+    }
+  }
+
+  private envInt(name: string, defaultVal: number): number {
+    const val = process.env[name];
+    if (!val) return defaultVal;
+    const parsed = parseInt(val, 10);
+    if (isNaN(parsed) || parsed <= 0) {
+      logger.warn(
+        `[BrowserPool] Invalid ${name}=${val}, using default ${defaultVal}`,
+      );
+      return defaultVal;
+    }
+    return parsed;
+  }
+}
+```
+
+**Step 2: Verify it compiles**
+
+Run: `npm run check`
+Expected: 0 errors
+
+**Step 3: Commit**
+
+```bash
+git add src/services/browserPool.ts
+git commit -m "feat: add BrowserPool with lazy creation, idle eviction, burst overflow"
+```
+
+---
+
+### Task 2: Refactor BrowserService — remove createBrowser, keep context/page
+
+**Files:**
+- Modify: `src/services/browserService.ts`
+
+**Step 1: Remove `createBrowser()`, `isBrowserNotInstalledError()`, and the `chromium` import**
+
+The pool now owns browser creation. BrowserService keeps context creation, page creation, anti-detection, and media handling. Also remove `cleanup()` — callers will close contexts directly, and the pool handles browser lifecycle.
+
+Remove:
+- Line 1: `chromium` from the import
+- Lines 133-177: `createBrowser()` and `isBrowserNotInstalledError()`
+- Lines 232-250: `cleanup()` method
+
+The `chromium` import becomes unused. The remaining import should be:
+```typescript
+import { Browser, BrowserContext, Page } from "playwright";
+```
+
+**Step 2: Verify it compiles**
+
+Run: `npm run check`
+Expected: Errors in fetchUrl.ts and fetchUrls.ts (they still call `createBrowser()` and `cleanup()`). That's expected — we fix those next.
+
+**Step 3: Commit**
+
+```bash
+git add src/services/browserService.ts
+git commit -m "refactor: remove browser lifecycle from BrowserService (pool owns it now)"
+```
+
+---
+
+### Task 3: Refactor fetchUrl to use BrowserPool
+
+**Files:**
+- Modify: `src/tools/fetchUrl.ts`
+
+**Step 1: Replace browser creation with pool acquire/release**
+
+The new flow: acquire handle from pool → create context → create page → process → close context → release handle.
+
+```typescript
+import { Page } from "playwright";
+import { WebContentProcessor } from "../services/webContentProcessor.js";
+import { BrowserService } from "../services/browserService.js";
+import { BrowserPool, BrowserHandle } from "../services/browserPool.js";
+import { FetchUrlArgsSchema, FetchOptionsSchema } from "../types/index.js";
+import { logger } from "../utils/logger.js";
+import { validateUrlProtocol } from "../utils/urlValidator.js";
+
+// ... fetchUrlTool definition unchanged ...
+
+export async function fetchUrl(args: Record<string, unknown> = {}) {
+  const parsed = FetchUrlArgsSchema.parse(args);
+  const url = parsed.url;
+
+  validateUrlProtocol(url);
+
+  const options = FetchOptionsSchema.parse(parsed);
+  const browserService = new BrowserService(options);
+  const processor = new WebContentProcessor(options, "[FetchURL]");
+
+  const pool = BrowserPool.getInstance();
+  let handle: BrowserHandle | null = null;
+  let page: Page | null = null;
+
+  try {
+    handle = await pool.acquire(browserService.isInDebugMode());
+    const { context, viewport } = await browserService.createContext(handle.browser);
+
+    try {
+      page = await browserService.createPage(context, viewport);
+      const result = await processor.processPageContent(page, url);
+
+      return {
+        content: [{ type: "text", text: result.content }],
+      };
+    } finally {
+      if (!browserService.isInDebugMode()) {
+        await context.close().catch((e) =>
+          logger.error(`[FetchURL] Failed to close context: ${e.message}`)
+        );
+      }
+    }
+  } finally {
+    if (handle) await handle.release();
+  }
+}
+```
+
+**Step 2: Verify it compiles**
+
+Run: `npm run check`
+Expected: fetchUrl clean, fetchUrls still has errors (next task)
+
+**Step 3: Commit**
+
+```bash
+git add src/tools/fetchUrl.ts
+git commit -m "refactor: fetchUrl uses BrowserPool acquire/release"
+```
+
+---
+
+### Task 4: Refactor fetchUrls to use BrowserPool
+
+**Files:**
+- Modify: `src/tools/fetchUrls.ts`
+
+**Step 1: Replace browser creation with pool acquire/release**
+
+Same pattern as fetchUrl. One acquire for the entire batch (all pages share the same browser). Context-per-page for isolation within the batch.
+
+```typescript
+import pLimit from "p-limit";
+import { WebContentProcessor } from "../services/webContentProcessor.js";
+import { BrowserService } from "../services/browserService.js";
+import { BrowserPool, BrowserHandle } from "../services/browserPool.js";
+import { FetchUrlsArgsSchema, FetchOptionsSchema, FetchResult } from "../types/index.js";
+import { logger } from "../utils/logger.js";
+import { validateUrlsProtocol } from "../utils/urlValidator.js";
+
+// ... fetchUrlsTool definition unchanged ...
+
+export async function fetchUrls(args: Record<string, unknown> = {}) {
+  const parsed = FetchUrlsArgsSchema.parse(args);
+  const urls = parsed.urls;
+
+  validateUrlsProtocol(urls);
+
+  const options = FetchOptionsSchema.parse(parsed);
+
+  let maxConcurrentPages = parseInt(
+    process.env.MAX_CONCURRENT_PAGES || "5",
+    10
+  );
+  if (isNaN(maxConcurrentPages) || maxConcurrentPages <= 0) {
+    logger.warn(
+      `Invalid MAX_CONCURRENT_PAGES value, using default of 5. Got: ${process.env.MAX_CONCURRENT_PAGES}`
+    );
+    maxConcurrentPages = 5;
+  }
+  const limit = pLimit(maxConcurrentPages);
+
+  const browserService = new BrowserService(options);
+  const processor = new WebContentProcessor(options, "[FetchURLs]");
+
+  const pool = BrowserPool.getInstance();
+  let handle: BrowserHandle | null = null;
+
+  try {
+    handle = await pool.acquire(browserService.isInDebugMode());
+
+    const settled = await Promise.allSettled(
+      urls.map((url, index) =>
+        limit(async () => {
+          const { context, viewport } = await browserService.createContext(handle!.browser);
+          try {
+            const page = await browserService.createPage(context, viewport);
+            try {
+              const result = await processor.processPageContent(page, url);
+              return { index, ...result } as FetchResult;
+            } finally {
+              if (!browserService.isInDebugMode()) {
+                await page.close().catch((e) =>
+                  logger.error(`[FetchURLs] Failed to close page: ${e.message}`)
+                );
+              }
+            }
+          } finally {
+            if (!browserService.isInDebugMode()) {
+              await context.close().catch((e) =>
+                logger.error(`[FetchURLs] Failed to close context: ${e.message}`)
+              );
+            }
+          }
+        })
+      ),
+    );
+
+    const results: FetchResult[] = settled.map((outcome, i) => {
+      if (outcome.status === "fulfilled") {
+        return outcome.value;
+      }
+      const errorMessage = outcome.reason instanceof Error
+        ? outcome.reason.message
+        : String(outcome.reason);
+      logger.error(`[FetchURLs] Failed to fetch URL ${urls[i]}: ${errorMessage}`);
+      return {
+        success: false,
+        content: `Title: Error\nURL: ${urls[i]}\nContent:\n\n<error>Failed to retrieve web page content: ${errorMessage}</error>`,
+        error: errorMessage,
+        index: i,
+      };
+    });
+
+    results.sort((a, b) => (a.index ?? 0) - (b.index ?? 0));
+    const combinedResults = results
+      .map(
+        (result, i) =>
+          `[webpage ${i + 1} begin]\n${result.content}\n[webpage ${i + 1} end]`,
+      )
+      .join("\n\n");
+
+    return {
+      content: [{ type: "text", text: combinedResults }],
+    };
+  } finally {
+    if (handle) await handle.release();
+  }
+}
+```
+
+**Step 2: Verify it compiles**
+
+Run: `npm run check`
+Expected: 0 errors
+
+**Step 3: Commit**
+
+```bash
+git add src/tools/fetchUrls.ts
+git commit -m "refactor: fetchUrls uses BrowserPool acquire/release"
+```
+
+---
+
+### Task 5: Wire pool into server lifecycle
+
+**Files:**
+- Modify: `src/server.ts` — add pool shutdown to graceful shutdown
+- Modify: `src/index.ts` — warm pool after server starts
+
+**Step 1: Add pool shutdown to server.ts**
+
+In `setupProcessHandlers`, update `gracefulShutdown` to also shut down the pool:
+
+```typescript
+import { BrowserPool } from "./services/browserPool.js";
+
+// In setupProcessHandlers, change gracefulShutdown to:
+const gracefulShutdown = async () => {
+  logger.info("[Server] Starting graceful shutdown...");
+  await BrowserPool.getInstance().shutdown();
+  return transportProvider.close();
+};
+```
+
+**Step 2: Add pool warming to index.ts**
+
+After `await startServer(transportProvider)`, add:
+
+```typescript
+import { BrowserPool } from "./services/browserPool.js";
+
+// After startServer call:
+await BrowserPool.getInstance().warm();
+```
+
+**Step 3: Verify it compiles and builds**
+
+Run: `npm run check && npm run build`
+Expected: 0 errors, clean build
+
+**Step 4: Commit**
+
+```bash
+git add src/server.ts src/index.ts
+git commit -m "feat: wire BrowserPool into server startup/shutdown lifecycle"
+```
+
+---
+
+### Task 6: Clean up BrowserService
+
+**Files:**
+- Modify: `src/services/browserService.ts`
+
+**Step 1: Remove dead code**
+
+After tasks 2-5, `createBrowser()`, `isBrowserNotInstalledError()`, and `cleanup()` should already be removed. Verify no dead methods remain. Also check that the browser-not-installed error hint still surfaces somewhere useful — it should, since `BrowserPool.launchBrowser()` will throw Playwright's native error which includes install instructions.
+
+**Step 2: Verify full pipeline**
+
+Run: `npm run check && npm run build`
+Expected: 0 errors, clean build
+
+**Step 3: Commit (if any cleanup was needed)**
+
+```bash
+git add src/services/browserService.ts
+git commit -m "refactor: clean up BrowserService after pool integration"
+```
+
+---
+
+### Task 7: Final verification
+
+**Step 1: Full quality check**
+
+Run: `npm run check && npm run build`
+Expected: 0 errors, clean build
+
+**Step 2: Manual smoke test**
+
+```bash
+# Quick test — start server, it should warm 1 browser
+node build/index.js --transport=http --host=127.0.0.1 --port=3000 --log 2>&1 &
+sleep 3
+
+# Check logs show pool warming
+# Kill with Ctrl+C — should show graceful shutdown + pool shutdown
+kill %1
+```
+
+**Step 3: Commit any final fixes, push**
+
+```bash
+git push origin main
+```

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@
 import { getConfig, isDebugMode } from "./config/index.js";
 import { createTransportProvider } from "./transports/index.js";
 import { startServer } from "./server.js";
+import { BrowserPool } from "./services/browserPool.js";
 import { logger } from "./utils/logger.js";
 
 /**
@@ -32,6 +33,9 @@ async function main() {
 
     // Start server
     await startServer(transportProvider);
+
+    // Pre-warm browser pool
+    await BrowserPool.getInstance().warm();
 
     logger.info("[Setup] Server started");
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,6 +5,7 @@ import {
 } from "@modelcontextprotocol/sdk/types.js";
 import { tools, toolHandlers } from "./tools/index.js";
 import { TransportProvider } from "./transports/types.js";
+import { BrowserPool } from "./services/browserPool.js";
 import { logger } from "./utils/logger.js";
 
 /**
@@ -56,6 +57,7 @@ function createServer() {
 function setupProcessHandlers(transportProvider: TransportProvider): void {
   const gracefulShutdown = async () => {
     logger.info("[Server] Starting graceful shutdown...");
+    await BrowserPool.getInstance().shutdown();
     return transportProvider.close();
   };
 

--- a/src/services/browserPool.ts
+++ b/src/services/browserPool.ts
@@ -1,0 +1,220 @@
+import { Browser, chromium } from "playwright";
+import { logger } from "../utils/logger.js";
+
+export interface BrowserHandle {
+  browser: Browser;
+  release(): Promise<void>;
+}
+
+interface PooledBrowser {
+  browser: Browser;
+  idleTimer: ReturnType<typeof setTimeout> | null;
+}
+
+export class BrowserPool {
+  private static instance: BrowserPool | null = null;
+
+  private idle: PooledBrowser[] = [];
+  private inUse = 0;
+  private poolSize: number;
+  private warmCount: number;
+  private idleTimeoutMs: number;
+  private shutdownRequested = false;
+
+  private constructor() {
+    this.poolSize = this.envInt("BROWSER_POOL_SIZE", 3);
+    this.warmCount = Math.min(
+      this.envInt("BROWSER_POOL_WARM", 1),
+      this.poolSize,
+    );
+    this.idleTimeoutMs = this.envInt("BROWSER_IDLE_TIMEOUT", 300) * 1000;
+  }
+
+  static getInstance(): BrowserPool {
+    if (!BrowserPool.instance) {
+      BrowserPool.instance = new BrowserPool();
+    }
+    return BrowserPool.instance;
+  }
+
+  /** Pre-warm browsers up to warmCount. Call after server starts. */
+  async warm(): Promise<void> {
+    const toCreate = this.warmCount - this.idle.length;
+    for (let i = 0; i < toCreate; i++) {
+      try {
+        const browser = await this.launchBrowser();
+        this.addToIdle(browser);
+        logger.info(`[BrowserPool] Warmed browser ${i + 1}/${toCreate}`);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        logger.error(`[BrowserPool] Failed to warm browser: ${msg}`);
+      }
+    }
+  }
+
+  /**
+   * Acquire a browser from the pool.
+   * - If debug is true, creates a temporary visible browser (never pooled).
+   * - Otherwise returns a pooled browser, creating or bursting as needed.
+   */
+  async acquire(debug = false): Promise<BrowserHandle> {
+    if (this.shutdownRequested) {
+      throw new Error("BrowserPool is shutting down");
+    }
+
+    // Debug requests always get a temporary visible browser
+    if (debug) {
+      const browser = await this.launchBrowser(false);
+      logger.debug("[BrowserPool] Created burst browser for debug request");
+      return {
+        browser,
+        release: async () => {
+          // Debug browsers stay open — don't close
+          logger.debug("[BrowserPool] Debug browser kept open");
+        },
+      };
+    }
+
+    // Try to get an idle browser
+    while (this.idle.length > 0) {
+      const pooled = this.idle.pop()!;
+      if (pooled.idleTimer) clearTimeout(pooled.idleTimer);
+
+      if (pooled.browser.isConnected()) {
+        this.inUse++;
+        logger.debug(
+          `[BrowserPool] Acquired idle browser (idle=${this.idle.length} inUse=${this.inUse})`,
+        );
+        return this.createHandle(pooled.browser, false);
+      }
+      // Dead browser — discard and try next
+      logger.warn("[BrowserPool] Discarded dead browser from pool");
+    }
+
+    // No idle browsers — create a new one
+    const isBurst = this.inUse >= this.poolSize;
+    const browser = await this.launchBrowser();
+    this.inUse++;
+
+    if (isBurst) {
+      logger.info(
+        `[BrowserPool] Created burst browser (inUse=${this.inUse}, poolSize=${this.poolSize})`,
+      );
+    } else {
+      logger.debug(
+        `[BrowserPool] Created new pooled browser (idle=${this.idle.length} inUse=${this.inUse})`,
+      );
+    }
+
+    return this.createHandle(browser, isBurst);
+  }
+
+  /** Graceful shutdown — close all browsers. */
+  async shutdown(): Promise<void> {
+    this.shutdownRequested = true;
+    logger.info("[BrowserPool] Shutting down...");
+
+    // Clear idle timers and close idle browsers
+    for (const pooled of this.idle) {
+      if (pooled.idleTimer) clearTimeout(pooled.idleTimer);
+      await this.closeBrowser(pooled.browser);
+    }
+    this.idle = [];
+
+    // In-use browsers will be closed when their handles are released
+    // (release() checks shutdownRequested)
+    logger.info("[BrowserPool] Shutdown complete");
+  }
+
+  /** Reset singleton — for testing only. */
+  static resetInstance(): void {
+    BrowserPool.instance = null;
+  }
+
+  private createHandle(browser: Browser, isBurst: boolean): BrowserHandle {
+    let released = false;
+    return {
+      browser,
+      release: async () => {
+        if (released) return;
+        released = true;
+        this.inUse--;
+
+        if (isBurst || this.shutdownRequested) {
+          await this.closeBrowser(browser);
+          if (isBurst) {
+            logger.debug("[BrowserPool] Destroyed burst browser");
+          }
+          return;
+        }
+
+        if (browser.isConnected()) {
+          this.addToIdle(browser);
+          logger.debug(
+            `[BrowserPool] Released browser to pool (idle=${this.idle.length} inUse=${this.inUse})`,
+          );
+        } else {
+          logger.warn("[BrowserPool] Released browser was dead, discarding");
+        }
+      },
+    };
+  }
+
+  private addToIdle(browser: Browser): void {
+    const pooled: PooledBrowser = { browser, idleTimer: null };
+
+    // Only set idle timer if we're above warm count
+    if (this.idle.length >= this.warmCount) {
+      pooled.idleTimer = setTimeout(() => {
+        const idx = this.idle.indexOf(pooled);
+        if (idx !== -1 && this.idle.length > this.warmCount) {
+          this.idle.splice(idx, 1);
+          this.closeBrowser(pooled.browser);
+          logger.info(
+            `[BrowserPool] Evicted idle browser (idle=${this.idle.length})`,
+          );
+        }
+      }, this.idleTimeoutMs);
+    }
+
+    this.idle.push(pooled);
+  }
+
+  private async launchBrowser(headless = true): Promise<Browser> {
+    return chromium.launch({
+      headless,
+      args: [
+        "--disable-blink-features=AutomationControlled",
+        "--disable-features=IsolateOrigins,site-per-process",
+        "--no-sandbox",
+        "--disable-setuid-sandbox",
+        "--disable-dev-shm-usage",
+        "--disable-webgl",
+        "--disable-infobars",
+        "--disable-extensions",
+      ],
+    });
+  }
+
+  private async closeBrowser(browser: Browser): Promise<void> {
+    try {
+      if (browser.isConnected()) await browser.close();
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      logger.error(`[BrowserPool] Failed to close browser: ${msg}`);
+    }
+  }
+
+  private envInt(name: string, defaultVal: number): number {
+    const val = process.env[name];
+    if (!val) return defaultVal;
+    const parsed = parseInt(val, 10);
+    if (isNaN(parsed) || parsed <= 0) {
+      logger.warn(
+        `[BrowserPool] Invalid ${name}=${val}, using default ${defaultVal}`,
+      );
+      return defaultVal;
+    }
+    return parsed;
+  }
+}

--- a/src/services/browserService.ts
+++ b/src/services/browserService.ts
@@ -1,9 +1,10 @@
-import { Browser, BrowserContext, Page, chromium } from "playwright";
-import { logger } from "../utils/logger.js";
+import { Browser, BrowserContext, Page } from "playwright";
 import { FetchOptions } from "../types/index.js";
 
 /**
- * Service for managing browser instances with anti-detection features
+ * Service for managing browser contexts and pages with anti-detection features.
+ * Browser lifecycle is now owned by BrowserPool — this service handles
+ * context creation, page creation, and stealth configuration.
  */
 export class BrowserService {
   private options: FetchOptions;
@@ -12,7 +13,7 @@ export class BrowserService {
   constructor(options: FetchOptions) {
     this.options = options;
     this.isDebugMode = process.argv.includes("--debug");
-    
+
     // Debug mode from options takes precedence over command line flag
     if (options.debug !== undefined) {
       this.isDebugMode = options.debug;
@@ -69,31 +70,31 @@ export class BrowserService {
       Object.defineProperty(navigator, 'webdriver', {
         get: () => false,
       });
-      
+
       // Remove automation fingerprints
       delete (window as any).cdc_adoQpoasnfa76pfcZLmcfl_Array;
       delete (window as any).cdc_adoQpoasnfa76pfcZLmcfl_Promise;
       delete (window as any).cdc_adoQpoasnfa76pfcZLmcfl_Symbol;
-      
+
       // Add Chrome object for fingerprinting evasion
       const chrome = {
         runtime: {},
       };
-      
+
       // Add fingerprint characteristics
       (window as any).chrome = chrome;
-      
+
       // Modify screen and navigator properties
       Object.defineProperty(screen, 'width', { value: window.innerWidth });
       Object.defineProperty(screen, 'height', { value: window.innerHeight });
       Object.defineProperty(screen, 'availWidth', { value: window.innerWidth });
       Object.defineProperty(screen, 'availHeight', { value: window.innerHeight });
-      
+
       // Add language features
       Object.defineProperty(navigator, 'languages', {
         get: () => ['en-US', 'en'],
       });
-      
+
       // Simulate random number of plugins
       Object.defineProperty(navigator, 'plugins', {
         get: () => {
@@ -128,60 +129,11 @@ export class BrowserService {
   }
 
   /**
-   * Create a new stealth browser instance
-   */
-  public async createBrowser(): Promise<Browser> {
-    const viewport = this.getRandomViewport();
-
-    try {
-      return await chromium.launch({
-        headless: !this.isDebugMode,
-        args: [
-          '--disable-blink-features=AutomationControlled',
-          '--disable-features=IsolateOrigins,site-per-process',
-          '--no-sandbox',
-          '--disable-setuid-sandbox',
-          '--disable-dev-shm-usage',
-          '--disable-webgl',
-          '--disable-infobars',
-          '--window-size=' + viewport.width + ',' + viewport.height,
-          '--disable-extensions'
-        ]
-      });
-    } catch (error: any) {
-      // Check if the error is related to missing browser installation
-      if (this.isBrowserNotInstalledError(error)) {
-        const enhancedError = new Error(
-          `Browser not installed. ${error.message}\n\n` +
-          `💡 To fix this issue, please call the 'browser_install' tool to install the required browser binaries.`
-        );
-        enhancedError.name = 'BrowserNotInstalledError';
-        throw enhancedError;
-      }
-      throw error;
-    }
-  }
-
-  /**
-   * Check if error is related to browser not being installed
-   */
-  private isBrowserNotInstalledError(error: any): boolean {
-    const errorMessage = error.message?.toLowerCase() || '';
-
-    return errorMessage.includes('executable doesn\'t exist') ||
-           errorMessage.includes('browser not found') ||
-           errorMessage.includes('could not find browser') ||
-           errorMessage.includes('failed to launch browser') ||
-           errorMessage.includes('browser executable not found') ||
-           errorMessage.includes('chromium browser not found');
-  }
-
-  /**
    * Create a new browser context with stealth configurations
    */
   public async createContext(browser: Browser): Promise<{ context: BrowserContext, viewport: {width: number, height: number} }> {
     const viewport = this.getRandomViewport();
-    
+
     const context = await browser.newContext({
       javaScriptEnabled: true,
       ignoreHTTPSErrors: true,
@@ -211,10 +163,10 @@ export class BrowserService {
 
     // Set up anti-detection measures
     await this.setupAntiDetection(context);
-    
+
     // Configure media handling
     await this.setupMediaHandling(context);
-    
+
     return { context, viewport };
   }
 
@@ -224,28 +176,5 @@ export class BrowserService {
   public async createPage(context: BrowserContext, _viewport: {width: number, height: number}): Promise<Page> {
     const page = await context.newPage();
     return page;
-  }
-
-  /**
-   * Clean up resources
-   */
-  public async cleanup(browser: Browser | null, page: Page | null, context: BrowserContext | null = null): Promise<void> {
-    if (!this.isDebugMode) {
-      if (page) {
-        await page
-          .close()
-          .catch((e) => logger.error(`Failed to close page: ${e.message}`));
-      }
-      if (context) {
-        await context
-          .close()
-          .catch((e) => logger.error(`Failed to close context: ${e.message}`));
-      }
-      if (browser) {
-        await browser
-          .close()
-          .catch((e) => logger.error(`Failed to close browser: ${e.message}`));
-      }
-    }
   }
 }

--- a/src/tools/fetchUrl.ts
+++ b/src/tools/fetchUrl.ts
@@ -1,6 +1,6 @@
-import { Browser, Page } from "playwright";
 import { WebContentProcessor } from "../services/webContentProcessor.js";
 import { BrowserService } from "../services/browserService.js";
+import { BrowserPool, BrowserHandle } from "../services/browserPool.js";
 import { FetchUrlArgsSchema, FetchOptionsSchema } from "../types/index.js";
 import { logger } from "../utils/logger.js";
 import { validateUrlProtocol } from "../utils/urlValidator.js";
@@ -80,45 +80,34 @@ export async function fetchUrl(args: Record<string, unknown> = {}) {
   const parsed = FetchUrlArgsSchema.parse(args);
   const url = parsed.url;
 
-  // Validate URL protocol for security (only allow HTTP and HTTPS)
   validateUrlProtocol(url);
 
   const options = FetchOptionsSchema.parse(parsed);
-
-  // Create browser service
   const browserService = new BrowserService(options);
-
-  // Create content processor
   const processor = new WebContentProcessor(options, "[FetchURL]");
-  let browser: Browser | null = null;
-  let page: Page | null = null;
 
-  if (browserService.isInDebugMode()) {
-    logger.debug(`Debug mode enabled for URL: ${url}`);
-  }
+  const pool = BrowserPool.getInstance();
+  let handle: BrowserHandle | null = null;
 
   try {
-    // Create a stealth browser with anti-detection measures
-    browser = await browserService.createBrowser();
+    handle = await pool.acquire(browserService.isInDebugMode());
+    const { context, viewport } = await browserService.createContext(handle.browser);
 
-    // Create a stealth browser context
-    const { context, viewport } = await browserService.createContext(browser);
+    try {
+      const page = await browserService.createPage(context, viewport);
+      const result = await processor.processPageContent(page, url);
 
-    // Create a new page with human-like behavior
-    page = await browserService.createPage(context, viewport);
-
-    // Process page content
-    const result = await processor.processPageContent(page, url);
-
-    return {
-      content: [{ type: "text", text: result.content }],
-    };
-  } finally {
-    // Clean up resources
-    await browserService.cleanup(browser, page);
-
-    if (browserService.isInDebugMode()) {
-      logger.debug(`Browser and page kept open for debugging. URL: ${url}`);
+      return {
+        content: [{ type: "text", text: result.content }],
+      };
+    } finally {
+      if (!browserService.isInDebugMode()) {
+        await context.close().catch((e: Error) =>
+          logger.error(`[FetchURL] Failed to close context: ${e.message}`)
+        );
+      }
     }
+  } finally {
+    if (handle) await handle.release();
   }
 }

--- a/src/tools/fetchUrls.ts
+++ b/src/tools/fetchUrls.ts
@@ -1,7 +1,7 @@
-import { Browser } from "playwright";
 import pLimit from "p-limit";
 import { WebContentProcessor } from "../services/webContentProcessor.js";
 import { BrowserService } from "../services/browserService.js";
+import { BrowserPool, BrowserHandle } from "../services/browserPool.js";
 import { FetchUrlsArgsSchema, FetchOptionsSchema, FetchResult } from "../types/index.js";
 import { logger } from "../utils/logger.js";
 import { validateUrlsProtocol } from "../utils/urlValidator.js";
@@ -83,12 +83,10 @@ export async function fetchUrls(args: Record<string, unknown> = {}) {
   const parsed = FetchUrlsArgsSchema.parse(args);
   const urls = parsed.urls;
 
-  // Validate all URL protocols for security (only allow HTTP and HTTPS)
   validateUrlsProtocol(urls);
 
   const options = FetchOptionsSchema.parse(parsed);
 
-  // Configure concurrency limit for page creation
   let maxConcurrentPages = parseInt(
     process.env.MAX_CONCURRENT_PAGES || "5",
     10
@@ -101,33 +99,36 @@ export async function fetchUrls(args: Record<string, unknown> = {}) {
   }
   const limit = pLimit(maxConcurrentPages);
 
-  // Create browser service
   const browserService = new BrowserService(options);
+  const processor = new WebContentProcessor(options, "[FetchURLs]");
 
-  if (browserService.isInDebugMode()) {
-    logger.debug(`Debug mode enabled for URLs: ${urls.join(", ")}`);
-  }
+  const pool = BrowserPool.getInstance();
+  let handle: BrowserHandle | null = null;
 
-  let browser: Browser | null = null;
   try {
-    browser = await browserService.createBrowser();
-    const { context, viewport } = await browserService.createContext(browser);
-    const processor = new WebContentProcessor(options, "[FetchURLs]");
+    handle = await pool.acquire(browserService.isInDebugMode());
 
     const settled = await Promise.allSettled(
       urls.map((url, index) =>
         limit(async () => {
-          const page = await browserService.createPage(context, viewport);
+          const { context, viewport } = await browserService.createContext(handle!.browser);
           try {
-            const result = await processor.processPageContent(page, url);
-            return { index, ...result } as FetchResult;
+            const page = await browserService.createPage(context, viewport);
+            try {
+              const result = await processor.processPageContent(page, url);
+              return { index, ...result } as FetchResult;
+            } finally {
+              if (!browserService.isInDebugMode()) {
+                await page.close().catch((e: Error) =>
+                  logger.error(`[FetchURLs] Failed to close page: ${e.message}`)
+                );
+              }
+            }
           } finally {
             if (!browserService.isInDebugMode()) {
-              await page
-                .close()
-                .catch((e) => logger.error(`Failed to close page: ${e.message}`));
-            } else {
-              logger.debug(`Page kept open for debugging. URL: ${url}`);
+              await context.close().catch((e: Error) =>
+                logger.error(`[FetchURLs] Failed to close context: ${e.message}`)
+              );
             }
           }
         })
@@ -162,13 +163,6 @@ export async function fetchUrls(args: Record<string, unknown> = {}) {
       content: [{ type: "text", text: combinedResults }],
     };
   } finally {
-    if (!browserService.isInDebugMode()) {
-      if (browser)
-        await browser
-          .close()
-          .catch((e) => logger.error(`Failed to close browser: ${e.message}`));
-    } else {
-      logger.debug(`Browser kept open for debugging. URLs: ${urls.join(", ")}`);
-    }
+    if (handle) await handle.release();
   }
 }


### PR DESCRIPTION
## Summary

- Add `BrowserPool` singleton that manages headless Chromium instances with acquire/release semantics, idle eviction timers, configurable warm count, and burst overflow for load spikes
- Refactor `BrowserService` to only handle context/page creation and stealth config — browser lifecycle moves to the pool
- Refactor `fetchUrl` and `fetchUrls` to acquire from pool, create isolated contexts per request/URL, and release on completion
- Wire pool warming into server startup and graceful shutdown into SIGTERM/SIGINT handlers

## Configuration

| Env var | Default | Purpose |
|---------|---------|---------|
| `BROWSER_POOL_SIZE` | 3 | Max pooled browsers before burst |
| `BROWSER_POOL_WARM` | 1 | Pre-warmed browsers on startup |
| `BROWSER_IDLE_TIMEOUT` | 300 | Seconds before idle eviction (above warm count) |

## Test Plan

- [x] `npm run check` — 0 errors
- [x] `npm run build` — clean build
- [x] Smoke test: HTTP server starts, pool warms 1 browser, SIGTERM triggers pool shutdown + transport close
- [ ] CI gate (`npm run check && npm run build`)